### PR TITLE
ci: add GitHub Actions validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+  PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+jobs:
+  backend:
+    name: Backend and compatibility gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Run backend and API contracts
+        run: npm run test:unit
+
+  e2e:
+    name: Real browser E2E
+    needs: backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Install Chromium and system dependencies
+        run: npx playwright install --with-deps chromium
+      - name: Run DOM-only Playwright regression suite
+        env:
+          E2E_RUN_DIR: ${{ runner.temp }}/phantom-e2e-runs
+        run: npm run test:e2e
+      - name: Upload Playwright report and failure evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-evidence-${{ github.run_attempt }}
+          path: |
+            test-results/
+            ${{ runner.temp }}/phantom-e2e-runs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -3,8 +3,12 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-PORT="${PORT:-3100}"
+# Keep the shared runner aligned with the server and legacy contract suites.
+PORT="${PORT:-3000}"
 BASE="${BASE_URL:-http://127.0.0.1:$PORT}"
+# Keep contract tests independent of whatever SQLite file a developer last
+# used while playing locally.
+TEST_DATA_DIR="${DATA_DIR:-$(mktemp -d)}"
 if [ -z "${NODE_BIN:-}" ]; then
   if [ -x "/opt/magnate/.node22/bin/node" ]; then
     NODE_BIN="/opt/magnate/.node22/bin/node --experimental-strip-types"
@@ -18,7 +22,7 @@ STANDALONE_RE="verify-issue-70-rest|verify-issue-7[8-9]|verify-issue-8[0-9]|veri
 
 pkill -9 -f "server/index.ts" 2>/dev/null || true
 sleep 1
-PORT="$PORT" SPEED_MULTIPLIER="${SPEED_MULTIPLIER:-200}" $NODE_BIN server/index.ts >/dev/null 2>&1 &
+PORT="$PORT" DATA_DIR="$TEST_DATA_DIR" SPEED_MULTIPLIER="${SPEED_MULTIPLIER:-200}" $NODE_BIN server/index.ts >/dev/null 2>&1 &
 SERVER_PID=$!
 sleep 2
 

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -5,8 +5,14 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-PORT="${PORT:-3100}"
+# The server and legacy contract suites default to port 3000. Keeping this
+# aligned avoids false failures from suites that intentionally use that public
+# default rather than BASE_URL.
+PORT="${PORT:-3000}"
 BASE="${BASE_URL:-http://127.0.0.1:$PORT}"
+# Use a fresh database unless a caller deliberately provides one. Old local
+# schemas must not make a regression run fail before the server can start.
+TEST_DATA_DIR="${DATA_DIR:-$(mktemp -d)}"
 if [ -z "${NODE_BIN:-}" ]; then
   if [ -x "/opt/magnate/.node22/bin/node" ]; then
     NODE_BIN="/opt/magnate/.node22/bin/node --experimental-strip-types"
@@ -21,7 +27,7 @@ STANDALONE_RE="verify-issue-70-rest|verify-issue-7[8-9]|verify-issue-8[0-9]|veri
 # Start shared server for API suites
 pkill -9 -f "server/index.ts" 2>/dev/null || true
 sleep 1
-PORT="$PORT" SPEED_MULTIPLIER="${SPEED_MULTIPLIER:-200}" $NODE_BIN server/index.ts >/dev/null 2>&1 &
+PORT="$PORT" DATA_DIR="$TEST_DATA_DIR" SPEED_MULTIPLIER="${SPEED_MULTIPLIER:-200}" $NODE_BIN server/index.ts >/dev/null 2>&1 &
 SERVER_PID=$!
 sleep 2
 

--- a/server/db/migrations/runner.ts
+++ b/server/db/migrations/runner.ts
@@ -206,11 +206,9 @@ export const MIGRATIONS: MigrationDefinition[] = [
         CREATE TABLE IF NOT EXISTS game_notifications (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           company_id INTEGER NOT NULL,
-          kind INTEGER NOT NULL,
-          title TEXT,
-          body TEXT NOT NULL,
-          link TEXT,
-          is_read INTEGER DEFAULT 0,
+          type TEXT NOT NULL,
+          payload_json TEXT DEFAULT '{}',
+          read INTEGER DEFAULT 0,
           created_at TEXT NOT NULL
         );
 
@@ -223,19 +221,24 @@ export const MIGRATIONS: MigrationDefinition[] = [
         );
 
         CREATE TABLE IF NOT EXISTS company_notes (
-          owner_company_id INTEGER NOT NULL,
-          target_company_id INTEGER NOT NULL,
-          note TEXT NOT NULL DEFAULT '',
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          company_id INTEGER NOT NULL,
+          about_company_id INTEGER NOT NULL,
+          note TEXT DEFAULT '',
+          priority INTEGER DEFAULT 0,
+          created_at TEXT,
           updated_at TEXT NOT NULL,
-          PRIMARY KEY (owner_company_id, target_company_id)
+          UNIQUE (company_id, about_company_id)
         );
 
         CREATE TABLE IF NOT EXISTS company_tags (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
           company_id INTEGER NOT NULL,
-          tag_text TEXT NOT NULL,
-          slot INTEGER NOT NULL,
+          resource_kind INTEGER NOT NULL,
+          kind TEXT NOT NULL,
+          buy_sell TEXT NOT NULL,
           created_at TEXT NOT NULL,
-          PRIMARY KEY (company_id, slot)
+          expires_at TEXT NOT NULL
         );
 
         CREATE TABLE IF NOT EXISTS achievements (
@@ -669,6 +672,90 @@ export const MIGRATIONS: MigrationDefinition[] = [
           attempted_at TEXT NOT NULL
         );
       `);
+    }
+  },
+  {
+    version: 12,
+    name: '012_social_schema_contracts',
+    up: (db: DatabaseSync) => {
+      const tagColumns = db.prepare('PRAGMA table_info(company_tags)').all() as Array<{ name: string }>;
+      if (!tagColumns.some(column => column.name === 'resource_kind')) {
+        // The old migration used text/slot tags even though the route contract
+        // stores a resource and buy/sell mode. Preserve values that can be
+        // represented before replacing that incompatible table.
+        const legacyTags = db.prepare(
+          'SELECT company_id, tag_text, created_at FROM company_tags'
+        ).all() as Array<{ company_id: number; tag_text: string; created_at: string }>;
+        db.exec(`
+          ALTER TABLE company_tags RENAME TO company_tags_legacy;
+          CREATE TABLE company_tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            company_id INTEGER NOT NULL,
+            resource_kind INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            buy_sell TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+          );
+        `);
+        const insertTag = db.prepare(
+          `INSERT INTO company_tags
+            (company_id, resource_kind, kind, buy_sell, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        );
+        const defaultExpiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+        for (const row of legacyTags) {
+          const match = /^(\d+)\s*([bs])$/i.exec(row.tag_text);
+          if (!match) continue;
+          const resourceKind = Number.parseInt(match[1], 10);
+          insertTag.run(row.company_id, resourceKind, String(resourceKind), match[2].toLowerCase(), row.created_at, defaultExpiry);
+        }
+        db.exec('DROP TABLE company_tags_legacy');
+      }
+
+      const notificationColumns = db.prepare('PRAGMA table_info(game_notifications)').all() as Array<{ name: string }>;
+      if (notificationColumns.some(column => column.name === 'read')) {
+        return;
+      }
+
+      const legacyNotifications = db.prepare(
+        'SELECT company_id, kind, title, body, link, is_read, created_at FROM game_notifications'
+      ).all() as Array<{
+        company_id: number;
+        kind: number;
+        title: string | null;
+        body: string;
+        link: string | null;
+        is_read: number;
+        created_at: string;
+      }>;
+      db.exec(`
+        ALTER TABLE game_notifications RENAME TO game_notifications_legacy;
+        CREATE TABLE game_notifications (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          company_id INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          payload_json TEXT DEFAULT '{}',
+          read INTEGER DEFAULT 0,
+          created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_game_notifications_company
+          ON game_notifications(company_id, read, created_at);
+      `);
+      const insertNotification = db.prepare(
+        `INSERT INTO game_notifications (company_id, type, payload_json, read, created_at)
+         VALUES (?, ?, ?, ?, ?)`
+      );
+      for (const row of legacyNotifications) {
+        insertNotification.run(
+          row.company_id,
+          `legacy-${row.kind}`,
+          JSON.stringify({ title: row.title, body: row.body, link: row.link }),
+          row.is_read,
+          row.created_at
+        );
+      }
+      db.exec('DROP TABLE game_notifications_legacy');
     }
   }
 ];


### PR DESCRIPTION
## What changed

- Adds GitHub Actions gates for backend/API contracts and real Chromium Playwright E2E.
- Uploads Playwright reports, screenshots, traces, and diagnostics on every E2E outcome.
- Makes test runners use a fresh SQLite directory and the legacy contract port (`3000`).
- Adds a migration to reconcile the social schemas used by runtime repositories.

## Validation

- YAML parsed successfully.
- `tests/verify-db-migrations.test.ts` passes with schema version 12.
- Clean startup still exposes a pre-existing next blocker: `newspaper_issues.published` rejects the `NULL` draft issue seeded by `server/game/newspaper.ts`. This draft is intentionally left unmerged until that contract is repaired.